### PR TITLE
choropleth add some transparency

### DIFF
--- a/client/src/components/OpenLayers/Style/ColorBrewerStyles.js
+++ b/client/src/components/OpenLayers/Style/ColorBrewerStyles.js
@@ -1,5 +1,6 @@
 import colorbrewer from "colorbrewer";
 import { Stroke, Fill, Style } from "ol/style";
+import { asArray as colorAsArray, asString as colorAsString } from "ol/color";
 
 const ColorBrewerStyles = {};
 for (const rampId in colorbrewer) {
@@ -19,7 +20,11 @@ for (const rampId in colorbrewer) {
             width: 2
           }),
           fill: new Fill({
-            color: colorbrewer[rampId][rampSize][i]
+            color: colorAsString(
+              colorAsArray(colorbrewer[rampId][rampSize][i])
+                .slice(0, 3)
+                .concat(0.7) // adjust opacity
+            ) // colarAsString gets rgba for legend
           })
         })
       );


### PR DESCRIPTION
Add a bit of transparency for choropleths (30%/70% opacity). Color passes thru to legend as rgba. Slight mismatch with graph.